### PR TITLE
Fixed bug on empty queries

### DIFF
--- a/routes/students.js
+++ b/routes/students.js
@@ -59,10 +59,11 @@ router.get('/classes', auth, (req, res) => {
             console.log([]);
             res.json([]);
         }
-
-        let arrClasses = classes.map(c => c.toObject());
-        console.log(arrClasses);
-        res.json(arrClasses);
+        else {
+            let arrClasses = classes.map(c => c.toObject());
+            console.log(arrClasses);
+            res.json(arrClasses);
+        }
     });
 });
 

--- a/routes/tutors.js
+++ b/routes/tutors.js
@@ -62,10 +62,11 @@ router.get('/classes', auth, (req, res) => {
             console.log([]);
             res.json([]);
         }
-
-        let arrClasses = classes.map(c => c.toObject());
-        console.log(arrClasses);
-        res.json(arrClasses);
+        else {
+            let arrClasses = classes.map(c => c.toObject());
+            console.log(arrClasses);
+            res.json(arrClasses);
+        }
     });
 });
 


### PR DESCRIPTION
When tutors/students wanted to see if there were any classes and there weren't any, server crashed